### PR TITLE
ci: add workflow_dispatch trigger and release job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,7 +5,9 @@ on:
   pull_request:
     branches:
     - '*'
-  # repository_dispatch is a newer github-actions feature that will allow building from triggers other than code merge/PR
+  workflow_dispatch:
+    branches:
+    - '*'
   repository_dispatch:
     types: [build]
 
@@ -48,3 +50,23 @@ jobs:
       with:
         name: IMUF_${{steps.file_version.outputs.VER}}
         path: output/*.bin
+
+  release:
+    needs: build
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/')
+    steps:
+
+    - name: Download artifacts
+      uses: actions/download-artifact@master
+
+    - name: Create Release
+      uses: softprops/action-gh-release@v2
+      with:
+        draft: true
+        generate_release_notes: true
+        body: |
+          Flash this firmware using the [IMUF Flasher](https://github.com/emuflight/Nemesis/releases/tag/imuf-flasher-0.1.0)
+        files: "**/*.bin"
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,7 +58,7 @@ jobs:
     steps:
 
     - name: Download artifacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v7
 
     - name: Create Release
       uses: softprops/action-gh-release@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,7 +43,7 @@ jobs:
       run: |
         VER=$(grep FIRMWARE_VERSION ./src/version.h  | awk '{print $3}')
         mv output/F3.bin output/IMUF_${VER}.bin
-        echo "::set-output name=VER::${VER}"
+        echo "VER=${VER}" >> "$GITHUB_OUTPUT"
 
     - name: Upload artifcats
       uses: actions/upload-artifact@master

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,9 @@ jobs:
         release: '6-2017-q1'
 
     - name: Setup Python
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v5
+      with:
+        python-version: '3.x'
 
     - name: Make
       run: ./make.py -T=F3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
       run: function curl () { command curl --connect-timeout 30 --retry 10 "$@" ; }
 
     - name: Checkout
-      uses: actions/checkout@master
+      uses: actions/checkout@v6
       with:
         fetch-depth: 15
 
@@ -46,7 +46,7 @@ jobs:
         echo "VER=${VER}" >> "$GITHUB_OUTPUT"
 
     - name: Upload artifcats
-      uses: actions/upload-artifact@master
+      uses: actions/upload-artifact@v7
       with:
         name: IMUF_${{steps.file_version.outputs.VER}}
         path: output/*.bin

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,8 +6,6 @@ on:
     branches:
     - '*'
   workflow_dispatch:
-    branches:
-    - '*'
   repository_dispatch:
     types: [build]
 
@@ -60,7 +58,7 @@ jobs:
     steps:
 
     - name: Download artifacts
-      uses: actions/download-artifact@master
+      uses: actions/download-artifact@v4
 
     - name: Create Release
       uses: softprops/action-gh-release@v2


### PR DESCRIPTION
## Summary
- Adds `workflow_dispatch` trigger so builds can be started manually from the GitHub Actions UI ("Run workflow" button), on any branch
- Removes outdated comment on `repository_dispatch`; trigger itself is retained for API-based builds
- Adds a `release` job that:
  - Runs only on tag pushes
  - Requires `build` job to succeed first
  - Creates a **draft** release (not auto-published)
  - Uses `generate_release_notes: true` for automatic PR/commit changelog
  - Attaches built `.bin` artifact as `IMUF_${VER}.bin` (e.g. `IMUF_257.bin`)
  - Includes link to [IMUF Flasher](https://github.com/emuflight/Nemesis/releases/tag/imuf-flasher-0.1.0) in release body

## Actions used
- `softprops/action-gh-release@v2` — `actions/create-release` was deprecated/archived by GitHub in 2021; this is the community standard replacement

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * The build workflow now supports manual triggering, allowing on-demand builds without requiring a push event.
  * Automated draft release creation has been implemented to streamline the release process, automatically generating releases with compiled artifacts when version tags are pushed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->