### PR TITLE
chore: suppress cppcheck unusedStructMember false positives

### DIFF
--- a/.codacy.yml
+++ b/.codacy.yml
@@ -1,0 +1,5 @@
+---
+engines:
+  cppcheck:
+    enabled: true
+    extraOptions: "--suppress=unusedStructMember"


### PR DESCRIPTION
## Summary

Codacy reports three `unusedStructMember` warnings:
- `pt1Filter_s::state` (filter.h:13)
- `pt1Filter_s::k` (filter.h:14)
- `kalman::kFilter` (kalman.h:23)

These are **false positives**. All three members are actively used via pointer indirection (`filter->state`, `filter->k`, `kalmanState->kFilter`) inside `pt1FilterInit()` and `pt1FilterApply()` — cppcheck does not track struct member usage through pointer dereference at call sites.

## Fix

Adds `.codacy.yml` with `--suppress=unusedStructMember` via cppcheck `extraOptions`. No code changes.

Follows the same pattern as emuflight/EmuFlight#1156.